### PR TITLE
StudCIaddition

### DIFF
--- a/R/bootstrap_lme4.R
+++ b/R/bootstrap_lme4.R
@@ -7,18 +7,18 @@ bootstrap.merMod <- function(model, .f = extract_parameters, type, B, resample,
                              reb_type, hccme, 
                              aux.dist, orig_data = NULL, .refit = TRUE, varest = "no"){
   switch(type,
-         parametric = parametric_bootstrap.merMod(model, .f, B, .refit, varest),
-         residual = resid_bootstrap.merMod(model, .f, B, .refit, varest),
+         parametric = parametric_bootstrap.merMod(model, .f, B, .refit, type, varest),
+         residual = resid_bootstrap.merMod(model, .f, B, .refit, type, varest),
          case = case_bootstrap.merMod(model, .f, B, resample, orig_data, .refit),
-         reb = reb_bootstrap.lmerMod(model, .f, B, reb_type, .refit, varest),
-         wild = wild_bootstrap.lmerMod(model, .f, B, hccme, aux.dist, .refit, varest))
+         reb = reb_bootstrap.lmerMod(model, .f, B, reb_type, .refit, type, varest),
+         wild = wild_bootstrap.lmerMod(model, .f, B, hccme, aux.dist, .refit, type, varest))
 }
 
 
 #' @rdname parametric_bootstrap
 #' @export
 #' @method parametric_bootstrap merMod
-parametric_bootstrap.merMod <- function(model, .f, B, .refit = TRUE, varest){
+parametric_bootstrap.merMod <- function(model, .f, B, .refit = TRUE, type, varest){
   if(.refit) .f <- match.fun(.f)
   
   # model.fixef <- lme4::fixef(model) # Extract fixed effects
@@ -27,7 +27,7 @@ parametric_bootstrap.merMod <- function(model, .f, B, .refit = TRUE, varest){
   if(!.refit) return(ystar)
   
   # refit here
-  refits <- refit_merMod(ystar, model, .f, varest)
+  refits <- refit_merMod(ystar, model, .f, type, varest)
   
   .bootstrap.completion(model, tstar = refits$tstar, B, .f, type = "parametric", warnings = refits$warnings)
 }
@@ -83,7 +83,7 @@ case_bootstrap.merMod <- function(model, .f, B, resample, orig_data = NULL, .ref
 #' @rdname resid_bootstrap
 #' @export
 #' @method resid_bootstrap merMod
-resid_bootstrap.merMod <- function(model, .f, B, .refit = TRUE, varest){
+resid_bootstrap.merMod <- function(model, .f, B, .refit = TRUE, type, varest){
   
   if(.refit) .f <- match.fun(.f)
   
@@ -122,7 +122,7 @@ resid_bootstrap.merMod <- function(model, .f, B, .refit = TRUE, varest){
   
   if(!.refit) return(ystar)
   
-  refits <- refit_merMod(ystar, model, .f, varest)
+  refits <- refit_merMod(ystar, model, .f, type, varest)
   
   .bootstrap.completion(model, tstar = refits$tstar, B, .f, type = "residual", warnings = refits$warnings)
 }
@@ -134,7 +134,7 @@ resid_bootstrap.merMod <- function(model, .f, B, .refit = TRUE, varest){
 wild_bootstrap.lmerMod <- function(model, .f, B, hccme = c("hc2", "hc3"), 
                                    aux.dist = c("mammen", "rademacher",
                                                 "norm", "webb", "gamma"),
-                                   .refit = TRUE, varest){
+                                   .refit = TRUE, type, varest){
   
   .f <- match.fun(.f)
   hccme <- match.arg(hccme)
@@ -160,7 +160,7 @@ wild_bootstrap.lmerMod <- function(model, .f, B, hccme = c("hc2", "hc3"),
   if(!.refit) return(ystar)
   
   
-  refits <- refit_merMod(ystar, model, .f, varest)
+  refits <- refit_merMod(ystar, model, .f, type, varest)
   
   .bootstrap.completion(model, tstar = refits$tstar, B, .f, type = "wild", warnings = refits$warnings)
 }
@@ -171,7 +171,7 @@ wild_bootstrap.lmerMod <- function(model, .f, B, hccme = c("hc2", "hc3"),
 #' @rdname reb_bootstrap
 #' @export
 #' @method reb_bootstrap lmerMod
-reb_bootstrap.lmerMod <- function(model, .f, B, reb_type, .refit = TRUE){
+reb_bootstrap.lmerMod <- function(model, .f, B, reb_type, .refit = TRUE, type, varest){
   
   if(missing(reb_type)){
     reb_type <- 0
@@ -211,7 +211,7 @@ reb_bootstrap.lmerMod <- function(model, .f, B, reb_type, .refit = TRUE){
   # Extract bootstrap statistics
   if(reb_type == 2) .f <- extract_parameters.merMod
   
-  refits <- refit_merMod(ystar, model, .f, varest)
+  refits <- refit_merMod(ystar, model, .f, type, varest)
   tstar <- refits$tstar
   # Extract original statistics
   t0 <- .f(model)

--- a/R/bootstrap_lme4.R
+++ b/R/bootstrap_lme4.R
@@ -10,7 +10,7 @@ bootstrap.merMod <- function(model, .f = extract_parameters, type, B, resample,
          parametric = parametric_bootstrap.merMod(model, .f, B, .refit, varest),
          residual = resid_bootstrap.merMod(model, .f, B, .refit, varest),
          case = case_bootstrap.merMod(model, .f, B, resample, orig_data, .refit),
-         reb = reb_bootstrap.lmerMod(model, .f, B, reb_type, .refit),
+         reb = reb_bootstrap.lmerMod(model, .f, B, reb_type, .refit, varest),
          wild = wild_bootstrap.lmerMod(model, .f, B, hccme, aux.dist, .refit, varest))
 }
 
@@ -211,7 +211,7 @@ reb_bootstrap.lmerMod <- function(model, .f, B, reb_type, .refit = TRUE){
   # Extract bootstrap statistics
   if(reb_type == 2) .f <- extract_parameters.merMod
   
-  refits <- refit_merMod(ystar, model, .f)
+  refits <- refit_merMod(ystar, model, .f, varest)
   tstar <- refits$tstar
   # Extract original statistics
   t0 <- .f(model)

--- a/R/bootstrap_lme4.R
+++ b/R/bootstrap_lme4.R
@@ -5,20 +5,20 @@
 #' na.omit predict resid simulate sd confint quantile
 bootstrap.merMod <- function(model, .f = extract_parameters, type, B, resample, 
                              reb_type, hccme, 
-                             aux.dist, orig_data = NULL, .refit = TRUE){
+                             aux.dist, orig_data = NULL, .refit = TRUE, varest = "no"){
   switch(type,
-         parametric = parametric_bootstrap.merMod(model, .f, B, .refit),
-         residual = resid_bootstrap.merMod(model, .f, B, .refit),
+         parametric = parametric_bootstrap.merMod(model, .f, B, .refit, varest),
+         residual = resid_bootstrap.merMod(model, .f, B, .refit, varest),
          case = case_bootstrap.merMod(model, .f, B, resample, orig_data, .refit),
          reb = reb_bootstrap.lmerMod(model, .f, B, reb_type, .refit),
-         wild = wild_bootstrap.lmerMod(model, .f, B, hccme, aux.dist, .refit))
+         wild = wild_bootstrap.lmerMod(model, .f, B, hccme, aux.dist, .refit, varest))
 }
 
 
 #' @rdname parametric_bootstrap
 #' @export
 #' @method parametric_bootstrap merMod
-parametric_bootstrap.merMod <- function(model, .f, B, .refit = TRUE){
+parametric_bootstrap.merMod <- function(model, .f, B, .refit = TRUE, varest){
   if(.refit) .f <- match.fun(.f)
   
   # model.fixef <- lme4::fixef(model) # Extract fixed effects
@@ -27,7 +27,7 @@ parametric_bootstrap.merMod <- function(model, .f, B, .refit = TRUE){
   if(!.refit) return(ystar)
   
   # refit here
-  refits <- refit_merMod(ystar, model, .f)
+  refits <- refit_merMod(ystar, model, .f, varest)
   
   .bootstrap.completion(model, tstar = refits$tstar, B, .f, type = "parametric", warnings = refits$warnings)
 }
@@ -83,7 +83,7 @@ case_bootstrap.merMod <- function(model, .f, B, resample, orig_data = NULL, .ref
 #' @rdname resid_bootstrap
 #' @export
 #' @method resid_bootstrap merMod
-resid_bootstrap.merMod <- function(model, .f, B, .refit = TRUE){
+resid_bootstrap.merMod <- function(model, .f, B, .refit = TRUE, varest){
   
   if(.refit) .f <- match.fun(.f)
   
@@ -122,7 +122,7 @@ resid_bootstrap.merMod <- function(model, .f, B, .refit = TRUE){
   
   if(!.refit) return(ystar)
   
-  refits <- refit_merMod(ystar, model, .f)
+  refits <- refit_merMod(ystar, model, .f, varest)
   
   .bootstrap.completion(model, tstar = refits$tstar, B, .f, type = "residual", warnings = refits$warnings)
 }
@@ -134,7 +134,7 @@ resid_bootstrap.merMod <- function(model, .f, B, .refit = TRUE){
 wild_bootstrap.lmerMod <- function(model, .f, B, hccme = c("hc2", "hc3"), 
                                    aux.dist = c("mammen", "rademacher",
                                                 "norm", "webb", "gamma"),
-                                   .refit = TRUE){
+                                   .refit = TRUE, varest){
   
   .f <- match.fun(.f)
   hccme <- match.arg(hccme)
@@ -160,7 +160,7 @@ wild_bootstrap.lmerMod <- function(model, .f, B, hccme = c("hc2", "hc3"),
   if(!.refit) return(ystar)
   
   
-  refits <- refit_merMod(ystar, model, .f)
+  refits <- refit_merMod(ystar, model, .f, varest)
   
   .bootstrap.completion(model, tstar = refits$tstar, B, .f, type = "wild", warnings = refits$warnings)
 }

--- a/R/lme4_utility_functions.R
+++ b/R/lme4_utility_functions.R
@@ -140,7 +140,7 @@ arrange_ranefs.lme <- function(b, fl, levs, cnms){
 #' @keywords internal
 #' @noRd
 #' @importFrom stats napredict
-refit_merMod <- function(ystar, model, .f, varest) {
+refit_merMod <- function(ystar, model, .f, type, varest) {
   error <- NULL
   
   # Adjustment to respect na.action
@@ -153,7 +153,7 @@ refit_merMod <- function(ystar, model, .f, varest) {
   
   f1 <- factory(
     function(model, y) 
-      .fvarest(y, model, .f, varest) #Original before StudCI addition .f(lme4::refit(object = model, newresp = y))
+      .fvarest(y, model, .f, type, varest) #Original before StudCI addition .f(lme4::refit(object = model, newresp = y))
   )
   stats <- purrr::map(ystar2, function(.y) f1(model, .y))
 

--- a/R/lme4_utility_functions.R
+++ b/R/lme4_utility_functions.R
@@ -146,15 +146,16 @@ refit_merMod <- function(ystar, model, .f, type, varest) {
   if (varest != "no") {
     
     if (!(varest == "analyticalf" | varest == "nestboot")) {
-      
       stop("Improper 'varest'. Use 'no' (default without definition), 'analyticalf', or 'nestboot'.")
-      
     }
     
     else if ((type == "reb" | type == "case") & (varest == "analyticalf" | varest == "nestboot")) {
-      
       stop("'varest' other than 'no' (default) currently not available for case or reb bootstrap methods.")
-      
+    }
+    
+    #These can be removed once the nestboot is implemented
+    else if (varest == "nestboot") {
+      stop("Variance estimation based on 'nestboot' not implemented yet. As 'varest', use 'no' (default without definition) or 'analyticalf'." )
     }
     
   }
@@ -261,8 +262,34 @@ prep_cases.merMod <- function(model, resample, orig_data) {
   
   #Acquire the refit-point estimate
   refitestimate <- .f(refit)
-  
-  #return the statistic, variance estimate not implemented yet
-  return(refitestimate)
 
+#Procedures for obtaining variance estimates (notice the varest-error checking done already in refit_merMod)
+if (varest != "no") {
+  
+  #Acquire the analytical variance
+  if (varest == "analyticalf") {
+    
+      #Obtain the variances
+      variances <- diag(vcov(refit))
+      
+    } else {
+    #"Placeholder for nested-bootstrap variance estimation, not implemented yet.
+    return(refitestimate)
+  }
+  
+  #Return the bootstrap estimates with variances
+  if(is.data.frame(refitestimate)) {
+  result <- cbind(refitestimate, data.frame(var = as.list(variances))) #The (Intercept) parentheses cause extra dots in the var name
+  return(result)
+    
+  } else {
+  result <- c(refitestimate, var = variances)
+  return(result)
+  }
+   
+  }
+
+  #No variance estimates were required, return the .f result only
+  return(refitestimate)
+  
 }

--- a/R/lme4_utility_functions.R
+++ b/R/lme4_utility_functions.R
@@ -153,7 +153,7 @@ refit_merMod <- function(ystar, model, .f) {
   
   f1 <- factory(
     function(model, y) 
-      .f(lme4::refit(object = model, newresp = y))
+      .fvarest(y, model, .f) #Original before StudCI addition .f(lme4::refit(object = model, newresp = y))
   )
   stats <- purrr::map(ystar2, function(.y) f1(model, .y))
 

--- a/R/lme4_utility_functions.R
+++ b/R/lme4_utility_functions.R
@@ -140,7 +140,7 @@ arrange_ranefs.lme <- function(b, fl, levs, cnms){
 #' @keywords internal
 #' @noRd
 #' @importFrom stats napredict
-refit_merMod <- function(ystar, model, .f) {
+refit_merMod <- function(ystar, model, .f, varest) {
   error <- NULL
   
   # Adjustment to respect na.action
@@ -153,7 +153,7 @@ refit_merMod <- function(ystar, model, .f) {
   
   f1 <- factory(
     function(model, y) 
-      .fvarest(y, model, .f) #Original before StudCI addition .f(lme4::refit(object = model, newresp = y))
+      .fvarest(y, model, .f, varest) #Original before StudCI addition .f(lme4::refit(object = model, newresp = y))
   )
   stats <- purrr::map(ystar2, function(.y) f1(model, .y))
 

--- a/R/lme4_utility_functions.R
+++ b/R/lme4_utility_functions.R
@@ -141,6 +141,24 @@ arrange_ranefs.lme <- function(b, fl, levs, cnms){
 #' @noRd
 #' @importFrom stats napredict
 refit_merMod <- function(ystar, model, .f, type, varest) {
+  
+  #Check varest for possible errors
+  if (varest != "no") {
+    
+    if (!(varest == "analyticalf" | varest == "nestboot")) {
+      
+      stop("Improper 'varest'. Use 'no' (default without definition), 'analyticalf', or 'nestboot'.")
+      
+    }
+    
+    else if ((type == "reb" | type == "case") & (varest == "analyticalf" | varest == "nestboot")) {
+      
+      stop("'varest' other than 'no' (default) currently not available for case or reb bootstrap methods.")
+      
+    }
+    
+  }
+  
   error <- NULL
   
   # Adjustment to respect na.action
@@ -153,7 +171,7 @@ refit_merMod <- function(ystar, model, .f, type, varest) {
   
   f1 <- factory(
     function(model, y) 
-      .fvarest(y, model, .f, type, varest) #Original before StudCI addition .f(lme4::refit(object = model, newresp = y))
+      .fvarest(y, model, .f, varest)
   )
   stats <- purrr::map(ystar2, function(.y) f1(model, .y))
 
@@ -236,7 +254,7 @@ prep_cases.merMod <- function(model, resample, orig_data) {
 }
 
 #Function for running .f and obtain variance estimates for bootstrap resamples
-.fvarest <- function(y, model, .f, type, varest) {
+.fvarest <- function(y, model, .f, varest) {
   
   #Refit the model
   refit <- lme4::refit(object = model, newresp = y)

--- a/R/lme4_utility_functions.R
+++ b/R/lme4_utility_functions.R
@@ -234,3 +234,17 @@ prep_cases.merMod <- function(model, resample, orig_data) {
   
   return(list(data, clusters))
 }
+
+#Function for running .f and obtain variance estimates for bootstrap resamples
+.fvarest <- function(y, model, .f, type, varest) {
+  
+  #Refit the model
+  refit <- lme4::refit(object = model, newresp = y)
+  
+  #Acquire the refit-point estimate
+  refitestimate <- .f(refit)
+  
+  #return the statistic, variance estimate not implemented yet
+  return(refitestimate)
+
+}


### PR DESCRIPTION
Here is the first part of the studentized-CI implementation. The bootstrap.merMod has an option to acquire the needed variances. Try using varest argument with “no” (default), “analyticalf” (obtains variances from vcov matrix), or “nestboot” (not implemented yet, only placeholder). The “analyticalf” works with .f() returning named nums or dataframes. The variances appear in the replicates of the result. The calculation of the confidence intervals themselves are not included yet.