### PR TITLE
Attempt to fix some R CMD Checks

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -8,6 +8,8 @@ on:
 
 name: R-CMD-check
 
+permissions: read-all
+
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
@@ -29,7 +31,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -47,3 +49,4 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,7 +29,6 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
-      HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: false
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -40,6 +40,8 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
+        env:
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: false
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,6 +29,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: false
 
     steps:
       - uses: actions/checkout@v4
@@ -40,8 +41,6 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
-        env:
-          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: false
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/R/generics.R
+++ b/R/generics.R
@@ -32,11 +32,11 @@
 #'     returned. Defaults to \code{TRUE}.
 #' @param rbootnoise a numeric value between 0-1 indicating the strength of
 #'     technical 2-level noise added in relation to the 1-level variation (in
-#'     standard deviations) during residual bootstrapping. Minuscule noise, such
-#'     as \code{rbootnoise = 0.0001}, can be used to avoid errors with singular
-#'     matrices when exactly the same values are replicated during the
-#'     bootstrapping, or when the model being processed fails to return any
-#'     2-level variation. Currently applicable only with \code{lme4::lmer}
+#'     standard deviations) during residual bootstrapping. Minuscule noise such
+#'     as \code{rbootnoise = 0.0001} can be used to avoid zero 2-level errors
+#'     and invalid matrix calculations. The feature can be used to finalize
+#'     the residual bootstrapping in technical sense, as such the reliability of the
+#'     analysis is not quaranteed. Applicable only with \code{lme4::lmer}
 #'     models. The feature has been tested with 2-level random-intercept models
 #'     with predictors. Defaults to \code{0} (i.e. the feature is not used by
 #'     default).


### PR DESCRIPTION
I noticed that there were some issues with the R CMD Checks. First, I updated the R-CMD-check.yaml to the latest recommended Standard Continuous Integration Workflow found here: https://github.com/r-lib/actions/tree/v2/examples#standard-ci-workflow

With that I was able to remove a few issues. For me the R CMD Check shows green success mark at the upper level on my repository. But as I dig down further I am still able to see a MacOS-related Error in the hidden Annotations here: https://github.com/IlmariTamminen/lmeresampler/actions/runs/9955801202

This is an universal error related to the MacOS container in which the R CMD Checks are executed, as far as I understand. An open pull request is already pending to fix the issue, we just need to wait:

https://github.com/r-lib/actions/pull/870

These R CMD checks are a little bit confusing. On the upper level a green check mark might be visible, and at the same time errors are hidden deeper in the info.

Best regards
Ilmari